### PR TITLE
Allow customizing page orientation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 build/
+src/templates/*.js
 .*.swp

--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ containing the output file.
     var converted = htmlDocx.asBlob(content);
     saveAs(converted, 'test.docx');
 
+`asBlob` can take additional options for controlling page setup for the document:
+
+* `orientation`: `landscape` or `portrait` (default)
+
+For example:
+
+    var converted = htmlDocx.asBlob(content, {orientation: 'landscape'});
+    saveAs(converted, 'test.docx');
+
 **IMPORTANT**: please pass a complete, valid HTML (including DOCTYPE, `html` and `body` tags).
 This may be less convenient, but gives you possibility of including CSS rules in `style` tags.
 
@@ -44,5 +53,5 @@ See `test/sample.html` for details.
 License
 -------
 
-Copyright (c) 2014 Evidence Prime, Inc.
+Copyright (c) 2015 Evidence Prime, Inc.
 See the LICENSE file for license rights and limitations (MIT).

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -7,6 +7,7 @@ prettyHrtime = require 'pretty-hrtime'
 notify = require 'gulp-notify'
 mocha = require 'gulp-mocha'
 mochaPhantomJS = require 'gulp-mocha-phantomjs'
+template = require 'gulp-lodash-template'
 
 startTime = null
 logger =
@@ -24,6 +25,9 @@ handleErrors = ->
     message: '<%= error.message %>'
   .apply this, arguments
   @emit 'end'
+
+precompileTemplates = ->
+  gulp.src('src/templates/*.tpl').pipe(template commonjs: true).pipe(gulp.dest('src/templates'))
 
 build = (test) ->
   [output, entry, options] = if test
@@ -48,6 +52,7 @@ build = (test) ->
   if global.isWatching
     bundler.on 'update', bundle
 
+  precompileTemplates()
   bundle()
 
 testsBundle = './test/index.coffee'
@@ -57,6 +62,7 @@ gulp.task 'build', -> build()
 gulp.task 'watch', ['setWatch', 'build']
 
 gulp.task 'test-node', (growl = false) ->
+  precompileTemplates()
   gulp.src(testsBundle, read: false).pipe mocha {reporter: 'spec', growl}
 gulp.task 'test-node-watch', ->
   sources = ['src/**', 'test/**']

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "chai": "^1.9.1",
     "coffeeify": "^0.6.0",
     "gulp": "^3.8.5",
+    "gulp-lodash-template": "^0.1.0",
     "gulp-mocha": "^0.4.1",
     "gulp-mocha-phantomjs": "^0.3.0",
     "gulp-notify": "^1.4.0",
@@ -36,6 +37,7 @@
     "watchify": "^0.10.2"
   },
   "dependencies": {
-    "jszip": "^2.3.0"
+    "jszip": "^2.3.0",
+    "lodash.assign": "^3.1.0"
   }
 }

--- a/src/api.coffee
+++ b/src/api.coffee
@@ -3,7 +3,7 @@ internal = require './internal'
 fs = require 'fs'
 
 module.exports =
-  asBlob: (html) ->
+  asBlob: (html, options) ->
     zip = new JSZip()
-    internal.addFiles(zip, html)
+    internal.addFiles(zip, html, options)
     internal.generateDocument(zip)

--- a/src/internal.coffee
+++ b/src/internal.coffee
@@ -1,4 +1,6 @@
 fs = require 'fs'
+documentTemplate = require './templates/document'
+_ = assign: require 'lodash.assign'
 
 module.exports =
   generateDocument: (zip) ->
@@ -12,11 +14,19 @@ module.exports =
       throw new Error "Neither Blob nor Buffer are accessible in this environment. " +
         "Consider adding Blob.js shim"
 
-  addFiles: (zip, htmlSource) ->
+  renderDocumentFile: (documentOptions = {}) ->
+    templateData = _.assign {},
+      switch documentOptions.orientation
+        when 'landscape' then height: 12240, width: 15840, orient: 'landscape'
+        else width: 12240, height: 15840, orient: 'portrait'
+
+    documentTemplate(templateData)
+
+  addFiles: (zip, htmlSource, documentOptions) ->
     zip.file '[Content_Types].xml', fs.readFileSync __dirname + '/assets/content_types.xml'
     zip.folder('_rels').file '.rels', fs.readFileSync __dirname + '/assets/rels.xml'
     zip.folder 'word'
-      .file 'document.xml', fs.readFileSync __dirname + '/assets/document.xml'
+      .file 'document.xml', @renderDocumentFile documentOptions
       .file 'afchunk.htm', htmlSource
       .folder '_rels'
         .file 'document.xml.rels', fs.readFileSync __dirname + '/assets/document.xml.rels'

--- a/src/templates/document.tpl
+++ b/src/templates/document.tpl
@@ -3,5 +3,8 @@
   <w:body>
     <w:altChunk r:id="htmlChunk" xmlns:r=
         "http://schemas.openxmlformats.org/officeDocument/2006/relationships" />
+    <w:sectPr>
+      <w:pgSz w:w="<%= width %>" w:h="<%= height %>" w:orient="<%= orient %>" />
+    </w:sectPr>
   </w:body>
 </w:document>

--- a/test/sample.html
+++ b/test/sample.html
@@ -10,6 +10,11 @@
 <body>
   <p>Enter/paste your document here:</p>
   <textarea id="content" cols="60" rows="10"></textarea>
+  <div class="page-orientation">
+    <span>Page orientation:</span>
+    <label><input type="radio" name="orientation" value="portrait" checked>Portrait</label>
+    <label><input type="radio" name="orientation" value="landscape">Landscape</label>
+  </div>
   <button id="convert">Convert</button>
   <div id="download-area"></div>
 
@@ -18,7 +23,7 @@
       selector: '#content',
       plugins: [
         "advlist autolink lists link image charmap print preview anchor",
-        "searchreplace visualblocks code fullscreen",
+        "searchreplace visualblocks code fullscreen fullpage",
         "insertdatetime media table contextmenu paste"
       ],
       toolbar: "insertfile undo redo | styleselect | bold italic | " +
@@ -28,7 +33,8 @@
     document.getElementById('convert').addEventListener('click', function(e) {
       e.preventDefault();
       var content = tinymce.get('content').getContent();
-      var converted = htmlDocx.asBlob(content);
+      var orientation = document.querySelector('.page-orientation input:checked').value;
+      var converted = htmlDocx.asBlob(content, {orientation: orientation});
 
       saveAs(converted, 'test.docx');
 


### PR DESCRIPTION
The various settings related to the page setup are defined in document
sections settings: http://officeopenxml.com/WPsection.php. Surprisingly,
even though Microsoft documentation explicitly states that setting the
orientation to landscape switches the dimensions (i.e. setting height to
20 and width to 40, while using landscape means that the height would
equal 40), my tests didn't show any such behavior. Additionally, not
specifying the page size makes Word ignore the page orientation setting,
so I needed to add default page size.

Initially, I precompiled the template using Browserify transformation
(https://github.com/zertosh/jstify), but I couldn't find a way to make
it work also for Node.js. So I opted for the simple solution of
pre-compiling the templates at the very beginning of the build process.
It means that `src/templates/template.tpl` is then available for
`require` as `src/templates/template`.

Test plan:
Use the provided 'test/sample.html' to export the document in portrait
and landscape orientations, using the radio buttons on the bottom.
