### PR TITLE
  Allow setting margin sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,19 @@ containing the output file.
 `asBlob` can take additional options for controlling page setup for the document:
 
 * `orientation`: `landscape` or `portrait` (default)
+* `margins`: map of margin sizes (expressed in twentieths of point, see
+  [WordprocessingML documentation](http://officeopenxml.com/WPsectionPgMar.php) for details):
+    - `top`: number (default: 1440, i.e. 2.54 cm)
+    - `right`: number (default: 1440)
+    - `bottom`: number (default: 1440)
+    - `left`: number (default: 1440)
+    - `header`: number (default: 720)
+    - `footer`: number (default: 720)
+    - `gutter`: number (default: 0)
 
 For example:
 
-    var converted = htmlDocx.asBlob(content, {orientation: 'landscape'});
+    var converted = htmlDocx.asBlob(content, {orientation: 'landscape', margins: {top: 720}});
     saveAs(converted, 'test.docx');
 
 **IMPORTANT**: please pass a complete, valid HTML (including DOCTYPE, `html` and `body` tags).

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "gulp-mocha-phantomjs": "^0.3.0",
     "gulp-notify": "^1.4.0",
     "gulp-util": "^2.2.19",
+    "jstify": "^0.9.0",
     "mocha": "^1.20.1",
     "pretty-hrtime": "^0.2.1",
     "sinon": "^1.10.2",
@@ -38,6 +39,7 @@
   },
   "dependencies": {
     "jszip": "^2.3.0",
-    "lodash.assign": "^3.1.0"
+    "lodash.escape": "^3.0.0",
+    "lodash.merge": "^3.2.0"
   }
 }

--- a/src/internal.coffee
+++ b/src/internal.coffee
@@ -1,6 +1,6 @@
 fs = require 'fs'
 documentTemplate = require './templates/document'
-_ = assign: require 'lodash.assign'
+_ = merge: require 'lodash.merge'
 
 module.exports =
   generateDocument: (zip) ->
@@ -15,10 +15,20 @@ module.exports =
         "Consider adding Blob.js shim"
 
   renderDocumentFile: (documentOptions = {}) ->
-    templateData = _.assign {},
+    templateData = _.merge margins:
+      top: 1440
+      right: 1440
+      bottom: 1440
+      left: 1440
+      header: 720
+      footer: 720
+      gutter: 0
+    ,
       switch documentOptions.orientation
         when 'landscape' then height: 12240, width: 15840, orient: 'landscape'
         else width: 12240, height: 15840, orient: 'portrait'
+    ,
+      margins: documentOptions.margins
 
     documentTemplate(templateData)
 

--- a/src/templates/document.tpl
+++ b/src/templates/document.tpl
@@ -5,6 +5,13 @@
         "http://schemas.openxmlformats.org/officeDocument/2006/relationships" />
     <w:sectPr>
       <w:pgSz w:w="<%= width %>" w:h="<%= height %>" w:orient="<%= orient %>" />
+      <w:pgMar w:top="<%= margins.top %>"
+               w:right="<%= margins.right %>"
+               w:bottom="<%= margins.bottom %>"
+               w:left="<%= margins.left %>"
+               w:header="<%= margins.header %>"
+               w:footer="<%= margins.footer %>"
+               w:gutter="<%= margins.gutter %>"/>
     </w:sectPr>
   </w:body>
 </w:document>

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -58,6 +58,17 @@ describe 'Rendering the Word document', ->
     expect(internal.renderDocumentFile(orientation: 'landscape')).to
       .match /<w:pgSz w:w="15840" w:h="12240" w:orient="landscape" \/>/
 
+  it 'should set default margins if no options were passed', ->
+    expect(internal.renderDocumentFile()).to.match /<w:pgMar w:top="1440"/
+    expect(internal.renderDocumentFile(orientation: 'landscape')).to.match /<w:pgMar w:top="1440"/
+
+  it 'should set the margin if it was specified as an option', ->
+    expect(internal.renderDocumentFile(margins: top: 123)).to.match /<w:pgMa[^>]*w:top="123"/
+
+  it 'should leave default values for margins that are not defined in the options', ->
+    expect(internal.renderDocumentFile(margins: left: 123)).to.match /<w:pgMar[^>]*w:left="123"/
+    expect(internal.renderDocumentFile(margins: left: 123)).to.match /<w:pgMar[^>]*w:top="1440"/
+
 describe 'Generating the document', ->
   beforeEach ->
     @zip = generate: sinon.stub().returns 'DEADBEEF'


### PR DESCRIPTION
This change also switches to pre-compiling the templates with the
Browserify transform. It was tricky to correctly watch for changes if
the templates were processed with outside of Browserify pipeline. Adding
extra extension to Browserify name resolving system solves the problem
with `require` calls across node.js and browser.